### PR TITLE
Fix bug in poi and tour description

### DIFF
--- a/app/models/record/poi_record.rb
+++ b/app/models/record/poi_record.rb
@@ -23,7 +23,7 @@ class PoiRecord < Record
   def convert_xml_to_hash
     poi_data = []
     tour_data = []
-
+    
     @xml_doc = Nokogiri.XML(xml_data)
     @xml_doc.remove_namespaces!
     @base_file_url = @xml_doc.at_xpath("/result/@fileUrl").try(:value)
@@ -41,8 +41,8 @@ class PoiRecord < Record
   def parse_single_poi_from_xml(poi)
     poi_data = {
       name: poi.attributes["name"].try(:value),
-      description: poi.xpath("description/text").try(:text),
-      mobile_description: poi.xpath("descriptionMobileSingle/text").try(:text),
+      description: poi.xpath("description/text/div").try(:to_s),
+      mobile_description: poi.xpath("descriptionMobileSingle/text/div").try(:to_s),
       category_name: parse_categories(poi).first,
       addresses: parse_addresses(poi),
       contact: parse_contact(poi.xpath("connections")),
@@ -63,8 +63,8 @@ class PoiRecord < Record
   def parse_single_tour_from_xml(tour)
     tour_data = {
       name: tour.attributes["name"].try(:value),
-      description: tour.xpath("description/text").try(:text),
-      mobile_description: tour.xpath("descriptionMobileSingle/text").try(:text),
+      description: tour.xpath("description/text/div").try(:to_s),
+      mobile_description: tour.xpath("descriptionMobileSingle/text/div").try(:to_s),
       category_name: parse_categories(tour).first,
       addresses: parse_addresses(tour),
       contact: parse_contact(tour.xpath("connections")),


### PR DESCRIPTION
* xml parser was parsing description as text and ignoring html tags
* fix bug by use of to_s method for nokogiri node to parse node entitty as it is.

After this PR is merged. POIs will be parsed like this:

![grafik](https://user-images.githubusercontent.com/31201899/60979125-75b50280-a332-11e9-9220-ae9729832b5d.png)

![grafik](https://user-images.githubusercontent.com/31201899/60979162-86657880-a332-11e9-8457-1cc0448691c6.png)

If the update action PR from the main App server(https://github.com/ikuseiGmbH/smart-village-app-mainserver/pull/108) is merged before this PR is merged, manual deletion of tours and pois won't be necessary anymore.
#17


